### PR TITLE
Cold start automation releated changes

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -94,6 +94,26 @@
 			"outDir": null
 		},
 		{
+			"name": "HelloWorldMvc-Test-ColdStart",
+			"type": "node",
+			"request": "launch",
+			"program": "${workspaceRoot}/client/controller.js",
+			"stopOnEntry": false,
+			"args": [ "--job", "test/coldstart/run-job-coldstart.json", "--topic", "controller/peterhsu-pc2", "--verbose"],
+			"cwd": "${workspaceRoot}/client",
+			"preLaunchTask": null,
+			"runtimeExecutable": null,
+			"runtimeArgs": [
+				"--nolazy"
+			],
+			"env": {
+				"NODE_ENV": "development"
+			},
+			"externalConsole": false,
+			"sourceMaps": false,
+			"outDir": null
+		},
+		{
 			"name": "MusicStore-Test-Controller",
 			"type": "node",
 			"request": "launch",

--- a/client/README.md
+++ b/client/README.md
@@ -27,15 +27,17 @@ Commands can be directly executed or options can be passed in using json as foll
 {
   command : "/home/aspuser/.dotnet/dotnet run"  
   cwd : "/home/aspuser/app/"
-  logfile : "dotnet_out.txt"
+  logfile : "dotnet_out.txt",
+  continueOnError : "true"
 }
 ```
 |Option| Description |
 |------|-------------|
-|command | The executable that needs to be launced on the target machine. |
-|cwd | The current workign directory that should be used when spawning the process.| 
+| command | The executable that needs to be launced on the target machine. |
+| cwd | The current workign directory that should be used when spawning the process.|
 | logfile | The file name used to output the stdout & stderr. The pid of the process is inserted into filename. So if the passed in filenamem is `output.txt` the output would be placed in `output_{pid}.txt` |  
-| env | Set of key value pairs which will be set before launch of the process. | 
+| env | Set of key value pairs which will be set before launch of the process. |
+| continueOnError | The job would typical fail if a command fails. However, if continueOnError is set to "true", the error would be ignored |
 
 ### Setting Environment Variables. 
 

--- a/client/args-util.js
+++ b/client/args-util.js
@@ -21,6 +21,7 @@ function add_creds(args) {
     var broker = credentials.broker;
     var options = [
         "--hostname", broker.host,
+        "--port", broker.port,
         "--username", broker.username,
         "--password", broker.password,
         "-q", "1"

--- a/client/controller.js
+++ b/client/controller.js
@@ -75,7 +75,7 @@ function start(inputargs) {
                     return;
                 }
             }
-    
+
             var nextcmd = msgProcessor.process(msg, args.topic);
             if (nextcmd == null) {
                 //client.end();

--- a/client/libs/mdparser.js
+++ b/client/libs/mdparser.js
@@ -57,7 +57,11 @@ function getcommandText(contents, index) {
                     var async = parts[1].match(/async=\"(.*?)\"/m);
                     if(async && async.length >1) {
                         command.async = (async[1] == "true") ? true:false;
-                    } 
+                    }
+                    var continueOnError = parts[1].match(/continueOnError=\"(.*?)\"/m);
+                    if(continueOnError && continueOnError.length > 1) {
+                        command.continueOnError = continueOnError[1].toLowerCase();
+                    }
                     return command;
                 }
             }

--- a/client/messageprocessor.js
+++ b/client/messageprocessor.js
@@ -73,7 +73,7 @@ function process(in_msg, callbacktopic) {
     var envid = "";
     
 
-    if (msg.exitcode && msg.exitcode != 0) {
+    if (msg.exitcode && msg.exitcode != 0 && msg.continueOnError != 'true') {
         console.log('[EndTest       ] ');
         console.log(colors.red("[Exec+Callback]  " + "ERR_EXITCODE" + msg.exitcode));
         return null;
@@ -145,6 +145,7 @@ function process(in_msg, callbacktopic) {
                     jobid: msg.jobid,
                     testid: msg.testid,
                     async: cmd.async,
+                    continueOnError: cmd.continueOnError,
                     exitcode: undefined
                 },
                 target: cmd.target

--- a/client/test/coldstart/run-coldstart-musicstore-inmemory-iis-core.json
+++ b/client/test/coldstart/run-coldstart-musicstore-inmemory-iis-core.json
@@ -1,0 +1,28 @@
+{
+    "logdir": "c:\\$(testid)",
+    "path" : "%localappdata%\\microsoft\\dotnet;%ProgramFiles%\\Git\\cmd",
+
+    "rebootCommand" : "shutdown /r /f /t 0",
+    "measureScript" : "Measure-IIS.ps1",
+    "publishScript" : "Publish-IIS.ps1",
+    "archiveScript" : "Archive-IIS.ps1",
+
+    "$targets": {
+        "server": {
+            "name": "Asp-xHPc7",
+            "targetApp" : "MusicStore",
+            "framework" : "netcoreapp1.0",
+
+            "gitHome" : "D:\\git\\aspnet",
+            "scriptSource": "https://github.com/aspnet/Performance.git",
+            "perfHome" : "D:\\git\\aspnet\\Performance",
+            "scriptHome" : "D:\\git\\aspnet\\Performance\\test\\ColdStart",
+
+            "testAppBranch" : "shhsu/coldstart_inmemory",
+            "testAppSource" : "https://github.com/aspnet/MusicStore.git",
+            "testAppHome" : "D:\\git\\aspnet\\MusicStore",
+            "testAppDir" : "D:\\git\\aspnet\\MusicStore\\src\\MusicStore"
+        }
+    }
+}
+

--- a/client/test/coldstart/run-coldstart-musicstore-inmemory-iis-desktop.json
+++ b/client/test/coldstart/run-coldstart-musicstore-inmemory-iis-desktop.json
@@ -1,0 +1,28 @@
+{
+    "logdir": "c:\\$(testid)",
+    "path" : "%localappdata%\\microsoft\\dotnet;%ProgramFiles%\\Git\\cmd",
+
+    "rebootCommand" : "shutdown /r /f /t 0",
+    "measureScript" : "Measure-IIS.ps1",
+    "publishScript" : "Publish-IIS.ps1",
+    "archiveScript" : "Archive-IIS.ps1",
+
+    "$targets": {
+        "server": {
+            "name": "Asp-xHPc7",
+            "targetApp" : "MusicStore",
+            "framework" : "net451",
+
+            "gitHome" : "D:\\git\\aspnet",
+            "scriptSource": "https://github.com/aspnet/Performance.git",
+            "perfHome" : "D:\\git\\aspnet\\Performance",
+            "scriptHome" : "D:\\git\\aspnet\\Performance\\test\\ColdStart",
+
+            "testAppBranch" : "shhsu/coldstart_inmemory",
+            "testAppSource" : "https://github.com/aspnet/MusicStore.git",
+            "testAppHome" : "D:\\git\\aspnet\\MusicStore",
+            "testAppDir" : "D:\\git\\aspnet\\MusicStore\\src\\MusicStore"
+        }
+    }
+}
+

--- a/client/test/coldstart/run-coldstart-musicstore-inmemory-linux-core.json
+++ b/client/test/coldstart/run-coldstart-musicstore-inmemory-linux-core.json
@@ -1,0 +1,27 @@
+{
+    "logdir": "/home/asplab/$(testid)",
+    "path" : "/home/asplab/.dotnet",
+
+    "rebootCommand" : "sudo shutdown -r now",
+    "measureScript" : "./Measure.sh",
+    "publishScript" : "./Publish.sh",
+    "archiveScript" : "./Archive.sh",
+
+    "$targets": {
+        "server": {
+            "name": "Asp-xHPSLC1",
+            "targetApp" : "MusicStore",
+            "framework" : "netcoreapp1.0",
+            
+            "gitHome" : "/home/asplab/git/aspnet",
+            "scriptSource": "https://github.com/aspnet/Performance.git",
+            "perfHome" : "/home/asplab/git/aspnet/Performance",
+            "scriptHome" : "/home/asplab/git/aspnet/Performance/test/ColdStart",
+
+            "testAppBranch" : "shhsu/coldstart_inmemory",
+            "testAppSource" : "https://github.com/aspnet/MusicStore.git",
+            "testAppHome" : "/home/asplab/git/aspnet/MusicStore",
+            "testAppDir" : "/home/asplab/git/aspnet/MusicStore/src/MusicStore"
+        }
+    }
+}

--- a/client/test/coldstart/run-coldstart-musicstore-inmemory-win-core.json
+++ b/client/test/coldstart/run-coldstart-musicstore-inmemory-win-core.json
@@ -1,0 +1,28 @@
+{
+    "logdir": "c:\\$(testid)",
+    "path" : "%localappdata%\\microsoft\\dotnet;%ProgramFiles%\\Git\\cmd",
+
+    "rebootCommand" : "shutdown /r /f /t 0",
+    "measureScript" : "Measure.ps1",
+    "publishScript" : "Publish.ps1",
+    "archiveScript" : "Archive.ps1",
+
+    "$targets": {
+        "server": {
+            "name": "Asp-xHPc7",
+            "targetApp" : "MusicStore",
+            "framework" : "netcoreapp1.0",
+
+            "gitHome" : "D:\\git\\aspnet",
+            "scriptSource": "https://github.com/aspnet/Performance.git",
+            "perfHome" : "D:\\git\\aspnet\\Performance",
+            "scriptHome" : "D:\\git\\aspnet\\Performance\\test\\ColdStart",
+
+            "testAppBranch" : "shhsu/coldstart_inmemory",
+            "testAppSource" : "https://github.com/aspnet/MusicStore.git",
+            "testAppHome" : "D:\\git\\aspnet\\MusicStore",
+            "testAppDir" : "D:\\git\\aspnet\\MusicStore\\src\\MusicStore"
+        }
+    }
+}
+

--- a/client/test/coldstart/run-coldstart-musicstore-inmemory-win-desktop.json
+++ b/client/test/coldstart/run-coldstart-musicstore-inmemory-win-desktop.json
@@ -1,0 +1,28 @@
+{
+    "logdir": "c:\\$(testid)",
+    "path" : "%localappdata%\\microsoft\\dotnet;%ProgramFiles%\\Git\\cmd",
+
+    "rebootCommand" : "shutdown /r /f /t 0",
+    "measureScript" : "Measure.ps1",
+    "publishScript" : "Publish.ps1",
+    "archiveScript" : "Archive.ps1",
+
+    "$targets": {
+        "server": {
+            "name": "Asp-xHPc7",
+            "targetApp" : "MusicStore",
+            "framework" : "net451",
+
+            "gitHome" : "D:\\git\\aspnet",
+            "scriptSource": "https://github.com/aspnet/Performance.git",
+            "perfHome" : "D:\\git\\aspnet\\Performance",
+            "scriptHome" : "D:\\git\\aspnet\\Performance\\test\\ColdStart",
+
+            "testAppBranch" : "shhsu/coldstart_inmemory",
+            "testAppSource" : "https://github.com/aspnet/MusicStore.git",
+            "testAppHome" : "D:\\git\\aspnet\\MusicStore",
+            "testAppDir" : "D:\\git\\aspnet\\MusicStore\\src\\MusicStore"
+        }
+    }
+}
+

--- a/client/test/coldstart/run-coldstart-musicstore-localdb-iis-core.json
+++ b/client/test/coldstart/run-coldstart-musicstore-localdb-iis-core.json
@@ -1,0 +1,28 @@
+{
+    "logdir": "c:\\$(testid)",
+    "path" : "%localappdata%\\microsoft\\dotnet;%ProgramFiles%\\Git\\cmd",
+
+    "rebootCommand" : "shutdown /r /f /t 0",
+    "measureScript" : "Measure-IIS.ps1",
+    "publishScript" : "Publish-IIS.ps1",
+    "archiveScript" : "Archive-IIS.ps1",
+
+    "$targets": {
+        "server": {
+            "name": "Asp-xHPc7",
+            "targetApp" : "MusicStore",
+            "framework" : "netcoreapp1.0",
+
+            "gitHome" : "D:\\git\\aspnet",
+            "scriptSource": "https://github.com/aspnet/Performance.git",
+            "perfHome" : "D:\\git\\aspnet\\Performance",
+            "scriptHome" : "D:\\git\\aspnet\\Performance\\test\\ColdStart",
+
+            "testAppBranch" : "shhsu/coldstart",
+            "testAppSource" : "https://github.com/aspnet/MusicStore.git",
+            "testAppHome" : "D:\\git\\aspnet\\MusicStore",
+            "testAppDir" : "D:\\git\\aspnet\\MusicStore\\src\\MusicStore"
+        }
+    }
+}
+

--- a/client/test/coldstart/run-coldstart-musicstore-localdb-win-core.json
+++ b/client/test/coldstart/run-coldstart-musicstore-localdb-win-core.json
@@ -1,0 +1,28 @@
+{
+    "logdir": "c:\\$(testid)",
+    "path" : "%localappdata%\\microsoft\\dotnet;%ProgramFiles%\\Git\\cmd",
+
+    "rebootCommand" : "shutdown /r /f /t 0",
+    "measureScript" : "Measure.ps1",
+    "publishScript" : "Publish.ps1",
+    "archiveScript" : "Archive.ps1",
+
+    "$targets": {
+        "server": {
+            "name": "Asp-xHPc7",
+            "targetApp" : "MusicStore",
+            "framework" : "netcoreapp1.0",
+
+            "gitHome" : "D:\\git\\aspnet",
+            "scriptSource": "https://github.com/aspnet/Performance.git",
+            "perfHome" : "D:\\git\\aspnet\\Performance",
+            "scriptHome" : "D:\\git\\aspnet\\Performance\\test\\ColdStart",
+
+            "testAppBranch" : "shhsu/coldstart",
+            "testAppSource" : "https://github.com/aspnet/MusicStore.git",
+            "testAppHome" : "D:\\git\\aspnet\\MusicStore",
+            "testAppDir" : "D:\\git\\aspnet\\MusicStore\\src\\MusicStore"
+        }
+    }
+}
+

--- a/client/test/coldstart/run-coldstart-musicstore-localdb-win-desktop.json
+++ b/client/test/coldstart/run-coldstart-musicstore-localdb-win-desktop.json
@@ -1,0 +1,28 @@
+{
+    "logdir": "c:\\$(testid)",
+    "path" : "%localappdata%\\microsoft\\dotnet;%ProgramFiles%\\Git\\cmd",
+
+    "rebootCommand" : "shutdown /r /f /t 0",
+    "measureScript" : "Measure.ps1",
+    "publishScript" : "Publish.ps1",
+    "archiveScript" : "Archive.ps1",
+
+    "$targets": {
+        "server": {
+            "name": "Asp-xHPc7",
+            "targetApp" : "MusicStore",
+            "framework" : "net451",
+
+            "gitHome" : "D:\\git\\aspnet",
+            "scriptSource": "https://github.com/aspnet/Performance.git",
+            "perfHome" : "D:\\git\\aspnet\\Performance",
+            "scriptHome" : "D:\\git\\aspnet\\Performance\\test\\ColdStart",
+
+            "testAppBranch" : "shhsu/coldstart",
+            "testAppSource" : "https://github.com/aspnet/MusicStore.git",
+            "testAppHome" : "D:\\git\\aspnet\\MusicStore",
+            "testAppDir" : "D:\\git\\aspnet\\MusicStore\\src\\MusicStore"
+        }
+    }
+}
+

--- a/client/test/coldstart/run-coldstart-mvc-iis-core.json
+++ b/client/test/coldstart/run-coldstart-mvc-iis-core.json
@@ -1,0 +1,28 @@
+{
+    "logdir": "c:\\$(testid)",
+    "path" : "%localappdata%\\microsoft\\dotnet;%ProgramFiles%\\Git\\cmd",
+
+    "rebootCommand" : "shutdown /r /f /t 0",
+    "measureScript" : "Measure-IIS.ps1",
+    "publishScript" : "Publish-IIS.ps1",
+    "archiveScript" : "Archive-IIS.ps1",
+
+    "$targets": {
+        "server": {
+            "name": "Asp-xHPc7",
+            "targetApp" : "HelloWorldMvc",
+            "framework" : "netcoreapp1.0",
+
+            "gitHome" : "D:\\git\\aspnet",
+            "scriptSource": "https://github.com/aspnet/Performance.git",
+            "perfHome" : "D:\\git\\aspnet\\Performance",
+            "scriptHome" : "D:\\git\\aspnet\\Performance\\test\\ColdStart",
+
+            "testAppBranch" : "shhsu/coldstart",
+            "testAppSource" : "https://github.com/aspnet/Performance.git",
+            "testAppHome" : "D:\\git\\aspnet\\Performance",
+            "testAppDir" : "null"
+        }
+    }
+}
+

--- a/client/test/coldstart/run-coldstart-mvc-iis-desktop.json
+++ b/client/test/coldstart/run-coldstart-mvc-iis-desktop.json
@@ -1,0 +1,28 @@
+{
+    "logdir": "c:\\$(testid)",
+    "path" : "%localappdata%\\microsoft\\dotnet;%ProgramFiles%\\Git\\cmd",
+
+    "rebootCommand" : "shutdown /r /f /t 0",
+    "measureScript" : "Measure-IIS.ps1",
+    "publishScript" : "Publish-IIS.ps1",
+    "archiveScript" : "Archive-IIS.ps1",
+
+    "$targets": {
+        "server": {
+            "name": "Asp-xHPc7",
+            "targetApp" : "HelloWorldMvc",
+            "framework" : "net451",
+
+            "gitHome" : "D:\\git\\aspnet",
+            "scriptSource": "https://github.com/aspnet/Performance.git",
+            "perfHome" : "D:\\git\\aspnet\\Performance",
+            "scriptHome" : "D:\\git\\aspnet\\Performance\\test\\ColdStart",
+
+            "testAppBranch" : "shhsu/coldstart",
+            "testAppSource" : "https://github.com/aspnet/Performance.git",
+            "testAppHome" : "D:\\git\\aspnet\\Performance",
+            "testAppDir" : "null"
+        }
+    }
+}
+

--- a/client/test/coldstart/run-coldstart-mvc-linux-core.json
+++ b/client/test/coldstart/run-coldstart-mvc-linux-core.json
@@ -1,0 +1,27 @@
+{
+    "logdir": "/home/asplab/$(testid)",
+    "path" : "/home/asplab/.dotnet",
+
+    "rebootCommand" : "sudo shutdown -r now",
+    "measureScript" : "./Measure.sh",
+    "publishScript" : "./Publish.sh",
+    "archiveScript" : "./Archive.sh",
+
+    "$targets": {
+        "server": {
+            "name": "Asp-xHPSLC1",
+            "targetApp" : "HelloWorldMvc",
+            "framework" : "netcoreapp1.0",
+            
+            "gitHome" : "/home/asplab/git/aspnet",
+            "scriptSource": "https://github.com/aspnet/Performance.git",
+            "perfHome" : "/home/asplab/git/aspnet/Performance",
+            "scriptHome" : "/home/asplab/git/aspnet/Performance/test/ColdStart",
+
+            "testAppBranch" : "shhsu/coldstart",
+            "testAppSource" : "https://github.com/aspnet/Performance.git",
+            "testAppHome" : "/home/asplab/git/aspnet/Performance",
+            "testAppDir" : "null"
+        }
+    }
+}

--- a/client/test/coldstart/run-coldstart-mvc-win-core.json
+++ b/client/test/coldstart/run-coldstart-mvc-win-core.json
@@ -1,0 +1,28 @@
+{
+    "logdir": "c:\\$(testid)",
+    "path" : "%localappdata%\\microsoft\\dotnet;%ProgramFiles%\\Git\\cmd",
+
+    "rebootCommand" : "shutdown /r /f /t 0",
+    "measureScript" : "Measure.ps1",
+    "publishScript" : "Publish.ps1",
+    "archiveScript" : "Archive.ps1",
+
+    "$targets": {
+        "server": {
+            "name": "Asp-xHPc7",
+            "targetApp" : "HelloWorldMvc",
+            "framework" : "netcoreapp1.0",
+
+            "gitHome" : "D:\\git\\aspnet",
+            "scriptSource": "https://github.com/aspnet/Performance.git",
+            "perfHome" : "D:\\git\\aspnet\\Performance",
+            "scriptHome" : "D:\\git\\aspnet\\Performance\\test\\ColdStart",
+
+            "testAppBranch" : "shhsu/coldstart",
+            "testAppSource" : "https://github.com/aspnet/Performance.git",
+            "testAppHome" : "D:\\git\\aspnet\\Performance",
+            "testAppDir" : "null"
+        }
+    }
+}
+

--- a/client/test/coldstart/run-coldstart-mvc-win-desktop.json
+++ b/client/test/coldstart/run-coldstart-mvc-win-desktop.json
@@ -1,0 +1,28 @@
+{
+    "logdir": "c:\\$(testid)",
+    "path" : "%localappdata%\\microsoft\\dotnet;%ProgramFiles%\\Git\\cmd",
+
+    "rebootCommand" : "shutdown /r /f /t 0",
+    "measureScript" : "Measure.ps1",
+    "publishScript" : "Publish.ps1",
+    "archiveScript" : "Archive.ps1",
+
+    "$targets": {
+        "server": {
+            "name": "Asp-xHPc7",
+            "targetApp" : "HelloWorldMvc",
+            "framework" : "net451",
+
+            "gitHome" : "D:\\git\\aspnet",
+            "scriptSource": "https://github.com/aspnet/Performance.git",
+            "perfHome" : "D:\\git\\aspnet\\Performance",
+            "scriptHome" : "D:\\git\\aspnet\\Performance\\test\\ColdStart",
+
+            "testAppBranch" : "shhsu/coldstart",
+            "testAppSource" : "https://github.com/aspnet/Performance.git",
+            "testAppHome" : "D:\\git\\aspnet\\Performance",
+            "testAppDir" : "null"
+        }
+    }
+}
+

--- a/client/test/coldstart/run-coldstart-text-iis-core.json
+++ b/client/test/coldstart/run-coldstart-text-iis-core.json
@@ -1,0 +1,28 @@
+{
+    "logdir": "c:\\$(testid)",
+    "path" : "%localappdata%\\microsoft\\dotnet;%ProgramFiles%\\Git\\cmd",
+
+    "rebootCommand" : "shutdown /r /f /t 0",
+    "measureScript" : "Measure-IIS.ps1",
+    "publishScript" : "Publish-IIS.ps1",
+    "archiveScript" : "Archive-IIS.ps1",
+
+    "$targets": {
+        "server": {
+            "name": "Asp-xHPc7",
+            "targetApp" : "BasicKestrel",
+            "framework" : "netcoreapp1.0",
+
+            "gitHome" : "D:\\git\\aspnet",
+            "scriptSource": "https://github.com/aspnet/Performance.git",
+            "perfHome" : "D:\\git\\aspnet\\Performance",
+            "scriptHome" : "D:\\git\\aspnet\\Performance\\test\\ColdStart",
+
+            "testAppBranch" : "shhsu/coldstart",
+            "testAppSource" : "https://github.com/aspnet/Performance.git",
+            "testAppHome" : "D:\\git\\aspnet\\Performance",
+            "testAppDir" : "null"
+        }
+    }
+}
+

--- a/client/test/coldstart/run-coldstart-text-iis-desktop.json
+++ b/client/test/coldstart/run-coldstart-text-iis-desktop.json
@@ -1,0 +1,28 @@
+{
+    "logdir": "c:\\$(testid)",
+    "path" : "%localappdata%\\microsoft\\dotnet;%ProgramFiles%\\Git\\cmd",
+
+    "rebootCommand" : "shutdown /r /f /t 0",
+    "measureScript" : "Measure-IIS.ps1",
+    "publishScript" : "Publish-IIS.ps1",
+    "archiveScript" : "Archive-IIS.ps1",
+
+    "$targets": {
+        "server": {
+            "name": "Asp-xHPc7",
+            "targetApp" : "BasicKestrel",
+            "framework" : "net451",
+
+            "gitHome" : "D:\\git\\aspnet",
+            "scriptSource": "https://github.com/aspnet/Performance.git",
+            "perfHome" : "D:\\git\\aspnet\\Performance",
+            "scriptHome" : "D:\\git\\aspnet\\Performance\\test\\ColdStart",
+
+            "testAppBranch" : "shhsu/coldstart",
+            "testAppSource" : "https://github.com/aspnet/Performance.git",
+            "testAppHome" : "D:\\git\\aspnet\\Performance",
+            "testAppDir" : "null"
+        }
+    }
+}
+

--- a/client/test/coldstart/run-coldstart-text-linux-core.json
+++ b/client/test/coldstart/run-coldstart-text-linux-core.json
@@ -1,0 +1,27 @@
+{
+    "logdir": "/home/asplab/$(testid)",
+    "path" : "/home/asplab/.dotnet",
+
+    "rebootCommand" : "sudo shutdown -r now",
+    "measureScript" : "./Measure.sh",
+    "publishScript" : "./Publish.sh",
+    "archiveScript" : "./Archive.sh",
+
+    "$targets": {
+        "server": {
+            "name": "Asp-xHPSLC1",
+            "targetApp" : "BasicKestrel",
+            "framework" : "netcoreapp1.0",
+            
+            "gitHome" : "/home/asplab/git/aspnet",
+            "scriptSource": "https://github.com/aspnet/Performance.git",
+            "perfHome" : "/home/asplab/git/aspnet/Performance",
+            "scriptHome" : "/home/asplab/git/aspnet/Performance/test/ColdStart",
+
+            "testAppBranch" : "shhsu/coldstart",
+            "testAppSource" : "https://github.com/aspnet/Performance.git",
+            "testAppHome" : "/home/asplab/git/aspnet/Performance",
+            "testAppDir" : "null"
+        }
+    }
+}

--- a/client/test/coldstart/run-coldstart-text-win-core.json
+++ b/client/test/coldstart/run-coldstart-text-win-core.json
@@ -1,0 +1,28 @@
+{
+    "logdir": "c:\\$(testid)",
+    "path" : "%localappdata%\\microsoft\\dotnet;%ProgramFiles%\\Git\\cmd",
+
+    "rebootCommand" : "shutdown /r /f /t 0",
+    "measureScript" : "Measure.ps1",
+    "publishScript" : "Publish.ps1",
+    "archiveScript" : "Archive.ps1",
+
+    "$targets": {
+        "server": {
+            "name": "Asp-xHPc7",
+            "targetApp" : "BasicKestrel",
+            "framework" : "netcoreapp1.0",
+
+            "gitHome" : "D:\\git\\aspnet",
+            "scriptSource": "https://github.com/aspnet/Performance.git",
+            "perfHome" : "D:\\git\\aspnet\\Performance",
+            "scriptHome" : "D:\\git\\aspnet\\Performance\\test\\ColdStart",
+
+            "testAppBranch" : "shhsu/coldstart",
+            "testAppSource" : "https://github.com/aspnet/Performance.git",
+            "testAppHome" : "D:\\git\\aspnet\\Performance",
+            "testAppDir" : "null"
+        }
+    }
+}
+

--- a/client/test/coldstart/run-coldstart-text-win-desktop.json
+++ b/client/test/coldstart/run-coldstart-text-win-desktop.json
@@ -1,0 +1,28 @@
+{
+    "logdir": "c:\\$(testid)",
+    "path" : "%localappdata%\\microsoft\\dotnet;%ProgramFiles%\\Git\\cmd",
+
+    "rebootCommand" : "shutdown /r /f /t 0",
+    "measureScript" : "Measure.ps1",
+    "publishScript" : "Publish.ps1",
+    "archiveScript" : "Archive.ps1",
+
+    "$targets": {
+        "server": {
+            "name": "Asp-xHPc7",
+            "targetApp" : "BasicKestrel",
+            "framework" : "net451",
+
+            "gitHome" : "D:\\git\\aspnet",
+            "scriptSource": "https://github.com/aspnet/Performance.git",
+            "perfHome" : "D:\\git\\aspnet\\Performance",
+            "scriptHome" : "D:\\git\\aspnet\\Performance\\test\\ColdStart",
+
+            "testAppBranch" : "shhsu/coldstart",
+            "testAppSource" : "https://github.com/aspnet/Performance.git",
+            "testAppHome" : "D:\\git\\aspnet\\Performance",
+            "testAppDir" : "null"
+        }
+    }
+}
+

--- a/client/test/coldstart/run-coldstart.md
+++ b/client/test/coldstart/run-coldstart.md
@@ -1,0 +1,22 @@
+# Startup scenario. Run 3 iterations of tests and archive the results
+
+| Command     | Host      |Description|
+|-------------|-----------|-----------|
+| `git clone -b shhsu/coldstart $(scriptSource)` <config cwd="$(gitHome)" continueOnError="true"/> | $(server) | Clone the scripts repo |
+| `git checkout shhsu/coldstart` <config cwd="$(perfHome)"/> | $(server) | Checkout, in case the clone command failed due to dir exists |
+| `git fetch --all` <config cwd="$(perfHome)"/> | $(server) | Fetch from git |
+| `git clean -xdf` <config cwd="$(perfHome)"/> | $(server) | Cleanup local perf repo |
+| `git reset --hard origin/shhsu/coldstart` <config cwd="$(perfHome)"/> | $(server) | Reset to coldstart branch |
+| `git clone -b $(testAppBranch) $(testAppSource)` <config cwd="$(gitHome)" continueOnError="true"/> | $(server) | Clone the test apps repo |
+| `git checkout $(testAppBranch)` <config cwd="$(testAppHome)"/> | $(server) | Checkout, in case the clone command failed due to dir exists |
+| `git fetch --all` <config cwd="$(testAppHome)"/> | $(server) | Fetch from git |
+| `git clean -xdf` <config cwd="$(testAppHome)"/> | $(server) | Cleanup local test app repo |
+| `git reset --hard origin/$(testAppBranch)` <config cwd="$(testAppHome)"/> | $(server) | Reset to coldstart branch |
+| `$(publishScript) -t $(targetApp) -f $(framework) -d $(testAppDir)` <config cwd="$(scriptHome)"> | $(server) | Publish App |
+| `$(rebootCommand)` | $(server) | Reboot |
+| `$(measureScript) -t $(targetApp) -f $(framework)` <config cwd="$(scriptHome)"> | $(server) | Measure Iteration 1 |
+| `$(rebootCommand)` | $(server) | Reboot |
+| `$(measureScript) -t $(targetApp) -f $(framework)` <config cwd="$(scriptHome)"> | $(server) | Measure Iteration 2 |
+| `$(rebootCommand)` | $(server) | Reboot |
+| `$(measureScript) -t $(targetApp) -f $(framework)` <config cwd="$(scriptHome)"> | $(server) | Measure Iteration 3 |
+| `$(archiveScript) -t $(targetApp) -f $(framework)` <config cwd="$(scriptHome)"> | $(server) | Archive Test Results |

--- a/client/test/coldstart/run-job-coldstart.json
+++ b/client/test/coldstart/run-job-coldstart.json
@@ -1,0 +1,6 @@
+{
+    "HelloWorldText-Windows-Core" : {
+        "spec" : "./test/coldstart/run-coldstart.md",
+        "env": "./test/coldstart/run-coldstart-text-win-core.json"
+    }
+}

--- a/client/test/run-job-helloworldmvc.json
+++ b/client/test/run-job-helloworldmvc.json
@@ -1,6 +1,6 @@
 {
     "HelloWorldMvc" : {
-        "testspec" : "./test/run-helloworldmvc.md",
-        "testenv": "./test/run-helloworldmvc-env.json"
+        "testspec" : "./test/run-helloworldmvc-win.md",
+        "testenv": "./test/run-helloworldmvc-win-env.json"
     }
 }


### PR DESCRIPTION
Cold start jobs.

Added a feature so that if a command fails the task would silently continue

Usage: put a start sign in front of the command in md file definition
i.e.

`*git clone -b shhsu/coldstart $(scriptSource)` <config cwd="$(gitHome)"/>

This command would fail if there's already a repository checked out at $(scriptSource). However, it is fine. We ignore this error. If the subsequent checkout and reset fails then we are in trouble and we will stop the task then.