### PR TITLE
Adding a field to specify broker port in client page

### DIFF
--- a/client/index.html
+++ b/client/index.html
@@ -41,6 +41,9 @@
           <input type="text" class="form-control" data-bind="value: broker" placeholder="Broker">
         </div>
         <div class="form-group">
+          <input type="number" class="form-control" data-bind="value: port" placeholder="Port">
+        </div>
+        <div class="form-group">
           <input type="text" class="form-control" data-bind="value: username" placeholder="Username">
         </div>
         <div class="form-group">

--- a/client/web/agent.js
+++ b/client/web/agent.js
@@ -52,7 +52,8 @@ var ViewModel = function () {
     function Subscribe() {
         // Create a client instance
 
-        client = new Paho.MQTT.Client(self.broker(), self.port(), guid());
+        console.log(self.port());
+        client = new Paho.MQTT.Client(self.broker(), parseInt(self.port()), guid());
 
         // set callback handlers
         client.onConnectionLost = onConnectionLost;


### PR DESCRIPTION
This is just in order to make it easier to select different ports when multiple brokers are running in the same host.

This is not a must-have, but it makes monitoring brokers much simpler.

@SajayAntony @sivagms 